### PR TITLE
Add GitHub Pages site

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ The example above stores the prompt, every model reply, and the final digest int
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to help.
 
+## Website
+
+Documentation is hosted with GitHub Pages from the `docs/` directory. If you own
+`ChatDelta.com`, point the domain's DNS at GitHub and add it as a custom domain
+in the repository settings. The [`docs/CNAME`](docs/CNAME) file already contains
+the domain name so GitHub Pages will serve the site at that address.
+
 ## License
 
 This project is released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+ChatDelta.com

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,19 @@
+# ChatDelta
+
+ChatDelta is an open source command line tool for comparing responses from multiple AI models. This site hosts the documentation and quick start guide.
+
+## Getting Started
+
+1. Install [Rust](https://www.rust-lang.org/tools/install).
+2. Clone the repository and build the binary:
+   ```bash
+   git clone https://github.com/ChatDelta/chatdelta.git
+   cd chatdelta
+   cargo build --release
+   ```
+3. Set your API keys as environment variables and run the CLI:
+   ```bash
+   OPENAI_API_KEY=... GEMINI_API_KEY=... ANTHROPIC_API_KEY=... ./target/release/chatdelta "Your prompt"
+   ```
+
+For full usage details see the [README](../README.md).


### PR DESCRIPTION
## Summary
- add initial Docs site served via GitHub Pages
- allow a custom domain through `docs/CNAME`
- document how to use the site

## Testing
- `cargo test` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_683f8e40752483259ff83490310a2112