### PR TITLE
Update README link for GitHub Pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,4 +16,4 @@ ChatDelta is an open source command line tool for comparing responses from multi
    OPENAI_API_KEY=... GEMINI_API_KEY=... ANTHROPIC_API_KEY=... ./target/release/chatdelta "Your prompt"
    ```
 
-For full usage details see the [README](../README.md).
+For full usage details see the [README on GitHub](https://github.com/ChatDelta/ChatDelta/blob/main/README.md).


### PR DESCRIPTION
## Summary
- fix README link on the docs site to use an absolute GitHub URL

## Testing
- `cargo test` *(fails: failed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684108811bac83258d5713141490665a